### PR TITLE
Relax docker-compose syntax to 3.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ $ docker run --cap-add=NET_ADMIN -d \
 
 ## Docker Compose
 ```
-version: '3.3'
+version: '3.2'
 services:
     deluge-openvpn:
         volumes:


### PR DESCRIPTION
Ubuntu, by default, doesn't include a docker-compose compatible with 3.3 and since you're not using any 3.3 features this change makes the code easier to run.