### PR TITLE
Don't disable ipv6

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ services:
             - LOCAL_NETWORK=192.168.0.0/16
         cap_add:
             - NET_ADMIN
+        sysctls:
+            - net.ipv6.conf.all.disable_ipv6=0
         logging:
             driver: json-file
             options:


### PR DESCRIPTION
Without this change, I get errors when OpenVPN is creating the tunnel (`RTNETLINK answers: Permission denied`). E.g.

```deluge-openvpn_1  | 2021-01-09 18:01:04 /sbin/ip link set dev tun0 up
deluge-openvpn_1  | 2021-01-09 18:01:04 /sbin/ip addr add dev tun0 <ipv4 addr>/24
deluge-openvpn_1  | 2021-01-09 18:01:04 /sbin/ip link set dev tun0 up mtu 1500
deluge-openvpn_1  | 2021-01-09 18:01:04 /sbin/ip link set dev tun0 up
deluge-openvpn_1  | 2021-01-09 18:01:04 /sbin/ip -6 addr add <ipv6 addr>/64 dev tun0
deluge-openvpn_1  | RTNETLINK answers: Permission denied
deluge-openvpn_1  | 2021-01-09 18:01:04 Linux ip -6 addr add failed: external program exited with error status: 2
deluge-openvpn_1  | 2021-01-09 18:01:04 Exiting due to fatal error
deluge_deluge-openvpn_1 exited with code 1
```